### PR TITLE
Ignore config files from checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* `check` ignores config file unless explicitly given by commandline #2
+
 ## 0.2.0 (2017-12-26)
 
 * Add `version` command

--- a/lib/goodcheck/commands/check.rb
+++ b/lib/goodcheck/commands/check.rb
@@ -46,7 +46,7 @@ module Goodcheck
 
       def each_check
         targets.each do |target|
-          each_file target do |path|
+          each_file target, immediate: true do |path|
             reporter.file(path) do
               buffers = {}
 
@@ -72,7 +72,7 @@ module Goodcheck
         end
       end
 
-      def each_file(path, &block)
+      def each_file(path, immediate: false, &block)
         realpath = path.realpath
 
         case
@@ -81,7 +81,12 @@ module Goodcheck
             each_file(child, &block)
           end
         when realpath.file?
-          yield path
+          if path == config_path
+            # Skip config file unless explicitly given by command line
+            yield path if immediate
+          else
+            yield path
+          end
         end
       end
     end


### PR DESCRIPTION
Stop checking the config file with `$ goodcheck check`. If you really want to check the config file, give the file to the commandline.