### PR TITLE
Tokenize non-ASCII words

### DIFF
--- a/lib/goodcheck/pattern.rb
+++ b/lib/goodcheck/pattern.rb
@@ -34,7 +34,7 @@ module Goodcheck
           tokens << Regexp.escape(s.matched)
         when s.scan(/\s+/)
           tokens << '\s+'
-        when s.scan(/(\p{Letter}|\w)+/)
+        when s.scan(/\w+|[\p{Letter}&&\p{^ASCII}]+/)
           tokens << Regexp.escape(s.matched)
         when s.scan(%r{[!"#$%&'=\-^~¥\\|`@*:+;/?.,]+})
           tokens << Regexp.escape(s.matched.rstrip)

--- a/test/pattern_test.rb
+++ b/test/pattern_test.rb
@@ -23,6 +23,13 @@ class PatternTest < Minitest::Test
     refute_match regexp, "Hello World <br >"
   end
 
+  def test_tokenize4
+    regexp = Goodcheck::Pattern.compile_tokens("沖縄Ruby会議")
+    assert_match regexp, "沖縄Ruby会議"
+    assert_match regexp, "沖縄 Ruby 会議"
+    refute_match regexp, "沖 縄Ruby会議"
+  end
+
   def test_literal
     pattern = Goodcheck::Pattern.literal("hello.world", case_insensitive: true)
     assert_equal /hello\.world/i, pattern.regexp


### PR DESCRIPTION
Goodcheck does not separate ASCII word and Kanji (or some non-ascii words).
But I expect it is separated. For example:

```
pattern:
  # It should match "猫Cat" and "猫 Cat", but it matches only "猫Cat" and does not match "猫 Cat" now.
  token: '猫Cat'
```

What do you think?