### PR TITLE
Stop resolving realpath for broken symlinks

### DIFF
--- a/lib/goodcheck/commands/check.rb
+++ b/lib/goodcheck/commands/check.rb
@@ -74,6 +74,8 @@ module Goodcheck
 
       def each_file(path, immediate: false, &block)
         case
+        when path.symlink?
+          # noop
         when path.directory?
           path.children.each do |child|
             each_file(child, &block)

--- a/lib/goodcheck/commands/check.rb
+++ b/lib/goodcheck/commands/check.rb
@@ -73,14 +73,12 @@ module Goodcheck
       end
 
       def each_file(path, immediate: false, &block)
-        realpath = path.realpath
-
         case
-        when realpath.directory?
+        when path.directory?
           path.children.each do |child|
             each_file(child, &block)
           end
-        when realpath.file?
+        when path.file?
           if path == config_path
             # Skip config file unless explicitly given by command line
             yield path if immediate

--- a/test/check_command_test.rb
+++ b/test/check_command_test.rb
@@ -64,7 +64,7 @@ EOF
         assert_equal 0, check.run
 
         assert_match %r(test\.yml:1:text: Github), stdout.string
-        assert_match %r(link\.yml:1:text: Github), stdout.string
+        refute_match %r(link\.yml:1:text: Github), stdout.string
       end
     end
   end

--- a/test/test_case_builder.rb
+++ b/test/test_case_builder.rb
@@ -27,6 +27,10 @@ class TestCaseBuilder
     (path + name).write(content.force_encoding(Encoding::ASCII_8BIT))
   end
 
+  def symlink(name:, original:)
+    (path + name).make_symlink(original)
+  end
+
   def self.tmpdir
     Dir.mktmpdir do |dir|
       yield self.new(path: Pathname(dir))


### PR DESCRIPTION
When goodcheck analyzes a broken symlink, it raises the following error:

```
$ goodcheck check --format json
Starting analysis...
No such file or directory @ realpath_rec - /tmp/symtest/test.yml

$ ls -l
total 4
-rw-r--r-- 1 wata727 251 Feb 21 15:03 goodcheck.yml
lrwxrwxrwx 1 wata727   8 Feb 21 15:04 link.yml -> test.yml
```

In order to avoid this error, it should stop resolving realpath.