### PR TITLE
Docker support🐳

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:2.5.0-stretch
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && \
+    apt-get install -y locales task-english && \
+    rm -rf /var/lib/apt/lists/*
+RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && \
+    locale-gen en_US.UTF-8 && \
+    update-locale en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
+
+RUN mkdir /goodcheck
+WORKDIR /goodcheck
+COPY . /goodcheck/
+RUN bundle install && bundle exec rake install
+
+RUN mkdir /work
+WORKDIR /work

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ $ gem install goodcheck
 
 Or you can use `bundler`!
 
+If you would not like to install Goodcheck to system (e.g. you would not liek to install Ruby 2.4 or higher), you can use a docker image. [See below](#docker-image).
+
 ## Quickstart
 
 ```bash
@@ -188,6 +190,20 @@ Use `test` command when you add new rule to be sure you are writing rules correc
 Available options is:
 
 * `-c [CONFIG]`, `--config=[CONFIG]` to specify the configuration file.
+
+## Docker image
+
+You can use a docker image to use Goodcheck.
+
+```bash
+$ git clone https://github.com/sideci/goodcheck
+$ cd goodcheck
+$ git checkout v1.0.0 # If you would like to use stable version.
+$ docker build -t goodcheck:latest .
+
+$ cd /path/to/your/project
+$ docker run -it --rm -v "$(pwd):/work" goodcheck:latest goodcheck check
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ gem install goodcheck
 
 Or you can use `bundler`!
 
-If you would not like to install Goodcheck to system (e.g. you would not liek to install Ruby 2.4 or higher), you can use a docker image. [See below](#docker-image).
+If you would not like to install Goodcheck to system (e.g. you would not like to install Ruby 2.4 or higher), you can use a docker image. [See below](#docker-image).
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ You can use a docker image to use Goodcheck.
 ```bash
 $ git clone https://github.com/sideci/goodcheck
 $ cd goodcheck
-$ git checkout v1.0.0 # If you would like to use stable version.
 $ docker build -t goodcheck:latest .
 
 $ cd /path/to/your/project

--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,9 @@ Rake::TestTask.new(:test) do |t|
 end
 
 task :default => :test
+
+namespace :docker do
+  task :build do
+    sh 'docker', 'build', '-t', 'goodcheck:latest', '.'
+  end
+end


### PR DESCRIPTION
Add Docker support. By this pull-request, user can use goodcheck with `docker build` and `docker run` if user does not install Ruby 2.4 in the host machine.

I think we can close #7 with this pull-request. What do you think? @soutaro @sumyapp 