### PR TITLE
Support {} syntax for glob

### DIFF
--- a/lib/goodcheck/config.rb
+++ b/lib/goodcheck/config.rb
@@ -13,7 +13,7 @@ module Goodcheck
             if rule.globs.empty?
               [rule, nil]
             else
-              glob = rule.globs.find {|glob| path.fnmatch?(glob.pattern, File::FNM_PATHNAME) }
+              glob = rule.globs.find {|glob| path.fnmatch?(glob.pattern, File::FNM_PATHNAME | File::FNM_EXTGLOB) }
               if glob
                 [rule, glob]
               end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -11,11 +11,13 @@ class ConfigTest < Minitest::Test
       loader.load_rule({ id: "rule1", glob: ["**/*.rb"], message: "" }),
       loader.load_rule({ id: "rule2", glob: ["*.rb", "app/views/**/*.html.erb"], message: "" }),
       loader.load_rule({ id: "rule3", glob: ["app/**/*.rb"], message: "" }),
+      loader.load_rule({ id: "rule4", glob: ["**/*.ts{,x}"], message: "" })
     ])
 
     assert_equal ["rule1", "rule2"], config.rules_for_path(Pathname("bar.rb"), rules_filter: []).map(&:first).map(&:id)
     assert_equal ["rule1", "rule3"], config.rules_for_path(Pathname("app/models/user.rb"), rules_filter: []).map(&:first).map(&:id)
     assert_equal ["rule2"], config.rules_for_path(Pathname("app/views/users/index.html.erb"), rules_filter: []).map(&:first).map(&:id)
+    assert_equal ["rule4"], config.rules_for_path(Pathname("frontend/src/foo.tsx"), rules_filter: []).map(&:first).map(&:id)
   end
 
   def test_rules_for_path_glob_empty


### PR DESCRIPTION
`glob` now supports `ts{x,}` syntax.