### PR TITLE
Speed-up processing of N literal patterns

### DIFF
--- a/test/config_loader_test.rb
+++ b/test/config_loader_test.rb
@@ -74,7 +74,7 @@ class ConfigLoaderTest < Minitest::Test
     assert_instance_of Rule, rule
     assert_equal "com.id.1", rule.id
     assert_equal "Some message", rule.message
-    assert_equal ["foo.bar"], rule.patterns.map(&:source)
+    assert_equal ["foo\\.bar"], rule.patterns.map(&:source)
     assert_equal [], rule.justifications
     assert_equal [], rule.globs
     assert_equal [], rule.passes
@@ -104,7 +104,7 @@ class ConfigLoaderTest < Minitest::Test
     assert_instance_of Rule, rule
     assert_equal "com.id.1", rule.id
     assert_equal "Some message", rule.message
-    assert_equal [/foo\.bar/, /foo\.bar\.baz/i, /foo/i], rule.patterns.map(&:regexp)
+    assert_equal [/foo\.bar/, /foo\.bar\.baz|foo/i], rule.patterns.map(&:regexp)
     assert_equal [], rule.justifications
     assert_equal [], rule.globs
     assert_equal [], rule.passes


### PR DESCRIPTION
A rule with N literal patters would
process each file N times for that rule.

Insted, split the literal patterns in two groups:
* case sensitive
* case insensitive

For each group combine the patterns into a regexp matching them.